### PR TITLE
 Add support for building packages from Adopt OpenJDK builds

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -18,6 +18,8 @@ Supported java binary distributions currently include:
     - The J2SE Development Kit (JDK), version 6, 7 and 8
     - The J2SE Runtime Environment (JRE), version 6, 7 and 8
     - The J2SE API Javadoc, version 6, 7 and 8
+   * AdoptOpenJDK (https://adoptopenjdk.net)
+    - The Java Development Kit (JDK), version 8 and 11
   (Choose tar.gz archives or self-extracting archives, do _not_ choose the RPM!)
 
 All other previously supported jvm (Blackdown, IBM, ..) have been removed and

--- a/debian/control
+++ b/debian/control
@@ -35,6 +35,8 @@ Description: Utility for creating Java Debian packages
      - The Java Development Kit (JDK), version 6, 7 and 8
      - The Java Runtime Environment (JRE), version 6, 7 and 8
      - The Java API Javadoc, version 6, 7 and 8
+   * AdoptOpenJDK (https://adoptopenjdk.net)
+    - The Java Development Kit (JDK), version 8 and 11
  Choose tar.gz archives or self-extracting archives (_not_ RPM).
  .
  Please note that Debian recommends the use of openjdk-[78]-jdk and/or

--- a/lib/adopt-open-jdk.sh
+++ b/lib/adopt-open-jdk.sh
@@ -1,0 +1,176 @@
+# Detect product
+j2se_detect_open_j2sdk=open_j2sdk_detect
+open_j2sdk_detect() {
+  j2se_release=0
+
+  # JDK 11 release candidate (OpenJDK11U-jdk_x64_linux_hotspot_11_28.tar.gz)
+  if [[ $archive_name =~ OpenJDK11U-jdk_x64_linux_hotspot_11([\.0-9]+)_([0-9]+)\.tar\.gz ]]
+  then
+      j2se_release=11
+      j2se_update="${BASH_REMATCH[1]}"
+      j2se_build="${BASH_REMATCH[2]}"
+      j2se_arch="x64"
+      j2se_version_name="${j2se_release}${j2se_update} version ${j2se_release}+${j2se_build}"
+      j2se_version="${j2se_release}${j2se_update}+${j2se_build}${revision}"
+      j2se_expected_min_size=180 #Mb
+      j2se_binary_subdir="/bin"
+      open_no_man_jre_bin_jre="jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200"
+      open_bin_jdk=" "
+      open_jre_bin_hl=" "
+      open_jre_bin_jre=" "
+  fi
+
+  # Open JDK 8 release candidate (OpenJDK8U-jdk_x64_linux_hotspot_8u181b13.tar.gz)
+  if [[ $archive_name =~ OpenJDK8U-jdk_x64_linux_hotspot_8([a-z][0-9]+)([a-z][0-9]+)\.tar\.gz ]]
+  then
+    j2se_release=8
+    j2se_update=${BASH_REMATCH[1]}
+    j2se_build=${BASH_REMATCH[2]}
+    j2se_arch=x64
+    j2se_version_name="${j2se_release} version ${j2se_release}${j2se_update}"
+    j2se_version="${j2se_release}${j2se_update}${j2se_build}${revision}"
+    j2se_expected_min_size=75 #Mb
+    j2se_binary_subdir="/bin"
+    open_no_man_jre_bin_jre="appletviewer extcheck idlj jar jarsigner java javac javadoc javah javap java-rmi.cgi jcmd jconsole jdb jdeps jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc"
+    open_bin_jdk=" "
+    open_jre_bin_hl=" "
+    open_jre_bin_jre=" "
+  fi
+
+  if [[ $j2se_release > 0 ]]
+  then
+    j2se_priority=$((310 + $j2se_release))
+    j2se_expected_min_size=${j2se_expected_min_size:-180} #Mb
+
+    # check if the architecture matches
+    let compatible=1
+
+    case "${DEB_BUILD_ARCH:-$DEB_BUILD_GNU_TYPE}" in
+      i386|i486-linux-gnu)
+        if [[ "$j2se_arch" != "i586" ]]; then compatible=0; fi
+        ;;
+      amd64|x86_64-linux-gnu)
+        if [[ "$j2se_arch" != "x64" && "$j2se_arch" != "amd64" ]]; then compatible=0; fi
+        ;;
+    esac
+
+    if [[ $compatible == 0 ]]
+    then
+      echo "The archive $archive_name is not supported on the ${DEB_BUILD_ARCH} architecture"
+      return
+    fi
+
+
+    cat << EOF
+
+Detected product:
+    Java(TM) Development Kit (JDK)
+    Standard Edition, Version $j2se_version_name
+    AdoptOpenJDK builds
+EOF
+    if read_yn "Is this correct [Y/n]: "; then
+      j2se_found=true
+      j2se_required_space=$(( $j2se_expected_min_size * 2 + 20 ))
+      j2se_vendor="adoptopenjdk"
+      j2se_title="Java Platform, Standard Edition $j2se_release Development Kit"
+
+      j2se_install=open_j2sdk_install
+      j2se_remove=open_j2sdk_remove
+      j2se_jinfo=open_j2sdk_jinfo
+      j2se_control=open_j2sdk_control
+      open_jre_bin_hl="${open_jre_bin_hl:-java javaws keytool orbd pack200 rmid rmiregistry servertool tnameserv unpack200 policytool}"
+      open_jre_bin_jre="${open_jre_bin_jre:-javaws policytool}"
+      if [ "${DEB_BUILD_ARCH:0:3}" != "arm" ]; then
+        open_no_man_jre_bin_jre="${open_no_man_jre_bin_jre:-ControlPanel jcontrol}"
+      fi
+      open_jre_lib_hl="jexec"
+      open_bin_jdk="${open_bin_jdk:-appletviewer extcheck idlj jar jarsigner javac javadoc javah javap jcmd jconsole jdb jdeps jhat jinfo jmap jmc jps jrunscript jsadebugd jstack jstat jstatd native2ascii rmic schemagen serialver wsgen wsimport xjc}"
+      j2se_package="$j2se_vendor-java$j2se_release-jdk"
+      j2se_binary_subdir="${j2se_binary_subdir:-/jre/bin}"
+      j2se_run
+    fi
+  fi
+}
+
+open_j2sdk_install() {
+    cat << EOF
+if [ ! -e "$jvm_base$j2se_name/debian/info" ]; then
+    exit 0
+fi
+
+install_alternatives $jvm_base$j2se_name${j2se_binary_subdir} $open_jre_bin_hl
+install_alternatives $jvm_base$j2se_name${j2se_binary_subdir} $open_jre_bin_jre
+if [ -n "$open_no_man_jre_bin_jre" ]; then
+    install_no_man_alternatives $jvm_base$j2se_name${j2se_binary_subdir} $open_no_man_jre_bin_jre
+fi
+install_no_man_alternatives $jvm_base$j2se_name/jre/lib $open_jre_lib_hl
+install_alternatives $jvm_base$j2se_name/bin $open_bin_jdk
+
+EOF
+}
+
+open_j2sdk_remove() {
+    cat << EOF
+if [ ! -e "$jvm_base$j2se_name/debian/info" ]; then
+    exit 0
+fi
+
+remove_alternatives $jvm_base$j2se_name${j2se_binary_subdir} $open_jre_bin_hl
+remove_alternatives $jvm_base$j2se_name${j2se_binary_subdir} $open_jre_bin_jre
+if [ -n "$open_no_man_jre_bin_jre" ]; then
+    remove_alternatives $jvm_base$j2se_name${j2se_binary_subdir} $open_no_man_jre_bin_jre
+fi
+remove_alternatives $jvm_base$j2se_name/jre/lib $open_jre_lib_hl
+remove_alternatives $jvm_base$j2se_name/bin $open_bin_jdk
+
+EOF
+}
+
+open_j2sdk_jinfo() {
+    cat << EOF
+name=$j2se_name
+priority=${priority_override:-$j2se_priority}
+section=main
+EOF
+    jinfos "hl" $jvm_base$j2se_name${j2se_binary_subdir}/ $open_jre_bin_hl
+    jinfos "jre" $jvm_base$j2se_name${j2se_binary_subdir}/ $open_jre_bin_jre
+    if [ -n "$open_no_man_jre_bin_jre" ]; then
+        jinfos "jre" $jvm_base$j2se_name${j2se_binary_subdir}/ $open_no_man_jre_bin_jre
+    fi
+    jinfos "hl" $jvm_base$j2se_name/jre/lib/ $open_jre_lib_hl
+    jinfos "jdk" $jvm_base$j2se_name/bin/ $open_bin_jdk
+}
+
+open_j2sdk_control() {
+    build_depends="libasound2, libgl1-mesa-glx, libgtk2.0-0, libxslt1.1, libxtst6, libxxf86vm1"
+    j2se_control
+    depends="\${shlibs:Depends}"
+    if [ "$create_cert_softlinks" == "true" ]; then
+        depends="$depends, ca-certificates-java"
+    fi
+    for i in `seq 5 ${j2se_release}`;
+    do
+        provides_runtime="${provides_runtime} java${i}-runtime,"
+        provides_headless="${provides_headless} java${i}-runtime-headless,"
+        provides_sdk="${provides_sdk} java${i}-sdk,"
+    done
+    cat << EOF
+Package: $j2se_package
+Architecture: $j2se_debian_arch
+Depends: \${misc:Depends}, java-common, $depends
+Recommends: netbase
+Provides: java-virtual-machine, java-runtime, java2-runtime, $provides_runtime java-compiler, java2-compiler, java-runtime-headless, java2-runtime-headless, $provides_headless java-sdk, java2-sdk, $provides_sdk
+Description: $j2se_title
+ The Java(TM) SE JDK is a development environment for building
+ applications, applets, and components that can be deployed on the
+ Java(TM) platform.
+ .
+ The Java(TM) SE JDK software includes tools useful for developing and
+ testing programs written in the Java programming language and running
+ on the Java platform. These tools are designed to be used from the
+ command line. Except for appletviewer, these tools do not provide a
+ graphical user interface.
+ .
+ This package has been automatically created with java-package ($version).
+EOF
+}

--- a/make-jpkg
+++ b/make-jpkg
@@ -76,6 +76,8 @@ Supported java binary distributions currently include:
     - The Java Development Kit (JDK), version 6, 7 and 8
     - The Java Runtime Environment (JRE), version 6, 7 and 8
     - The Java API Javadoc, version 6, 7 and 8
+  * AdoptOpenJDK (https://adoptopenjdk.net)
+    - The Java Development Kit (JDK), version 8 and 11
   (Choose tar.gz archives or self-extracting archives, do _not_ choose the RPM!)
 
 The following options are recognized:

--- a/make-jpkg.1
+++ b/make-jpkg.1
@@ -33,6 +33,8 @@ Supported java binary distributions currently include:
     - The Java Development Kit (JDK), version 6, 7 and 8
     - The Java Runtime Environment (JRE), version 6, 7 and 8
     - The Java API Javadoc, version 6, 7 and 8
+  * AdoptOpenJDK (https://adoptopenjdk.net)
+    - The Java Development Kit (JDK), version 8 and 11
   (Choose tar.gz archives or self-extracting archives, do _not_ choose the RPM!)
 .PP
 The following options are recognized:


### PR DESCRIPTION
This code helps to build debian packages for AdoptOpenJDK x64 Linux builds.
**Testing**
Built the package on `bootstrap-18-04` system to generate java-package debian `java-package_0.63_all.deb`

```
Package: java-package
Version: 0.63
Status: install ok installed
Priority: optional
Section: contrib/misc
Maintainer: Debian Java Maintainers <pkg-java-maintainers@lists.alioth.debian.org>
Installed-Size: 78.8 kB
Depends: debhelper (>= 11), build-essential, dpkg-dev, fakeroot, libasound2, libfontconfig1, libgl1-mesa-glx, libgtk2.0-0, libx11-6, libxslt1.1, libxtst6, libxxf86vm1, unzip
Suggests: openjdk-8-jre
Download-Size: unknown
APT-Manual-Installed: yes
APT-Sources: /var/lib/dpkg/status
Description: Utility for creating Java Debian packages
 This package provides the capability to build a Debian package from
 a Java binary distribution by running make-jpkg <java binary archive file>.
 (with archive files downloaded from providers listed below)
 .
 Supported java binary distributions currently include:
   * Oracle (http://www.oracle.com/technetwork/java/javase/downloads) :
     - The Java Development Kit (JDK), version 6, 7 and 8
     - The Java Runtime Environment (JRE), version 6, 7 and 8
     - The Java API Javadoc, version 6, 7 and 8
   * AdoptOpenJDK (https://adoptopenjdk.net)
    - The Java Development Kit (JDK), version 8 and 11
 Choose tar.gz archives or self-extracting archives (_not_ RPM).
 .
 Please note that Debian recommends the use of openjdk-[78]-jdk and/or
 openjdk-[78]-jre, which are installed by default-jdk or default-jre for
 most architectures.
 .
 java-package will create non-free packages.
```

Downloaded AdoptOpenJDK x64 linux .tar.gz to create debian package.
run 
`sudo apt install libgl1-mesa-glx`
`sudo dpkg -i java-package_0.63_all.deb`
`env DEB_BUILD_OPTIONS=nostrip fakeroot make-jpkg OpenJDK8U-jdk_x64_linux_hotspot_8u192b12.tar.gz`
